### PR TITLE
Fix memory leaks after agent reconnect

### DIFF
--- a/Src/firmware/mainf.cpp
+++ b/Src/firmware/mainf.cpp
@@ -509,6 +509,7 @@ void loop() {
       break;
     case AgentStatus::AGENT_LOST:
       controller->disable();
+      finiController();
       finiROS();
       status = AgentStatus::CONNECTING_TO_AGENT;
       break;


### PR DESCRIPTION
Finishing robot controller when uROS agent is lost, which cleans the stack from allocated memory