### PR TITLE
Fix hard fault occurring when agent is lost during boot state

### DIFF
--- a/App/Src/app.cpp
+++ b/App/Src/app.cpp
@@ -570,8 +570,10 @@ void loop() {
       }
       break;
     case AgentStatus::AGENT_LOST:
-      controller->disable();
-      finiController();
+      if (controller_initialized) {
+        controller->disable();
+        finiController();
+      }
       finiROS();
       status = AgentStatus::CONNECTING_TO_AGENT;
       break;


### PR DESCRIPTION
Transitioning from BOOT to AGENT_LOST will cause dereference of `controller` before `initController` is called.