### PR TITLE
feat: Use new diff_drive_lib and PID tuning, add acceleration ramps

### DIFF
--- a/App/Inc/app/motor_controller.hpp
+++ b/App/Inc/app/motor_controller.hpp
@@ -13,7 +13,7 @@ struct MotorConfiguration {
   volatile uint16_t *vpropi_adc;
 };
 
-class MotorController : public diff_drive_lib::MotorControllerInterface {
+class MotorController : public diff_drive_lib::MotorControllerBase {
  public:
   MotorController(const MotorConfiguration &config) : config_(config) {};
 

--- a/App/Inc/app/parameters.hpp
+++ b/App/Inc/app/parameters.hpp
@@ -13,6 +13,7 @@ struct Parameters : diff_drive_lib::RobotParams {
     wheel_pid_p = 2.64F;
     wheel_pid_i = 42.24F;
     wheel_pid_d = 0.11F;
+    wheel_max_voltage = 26.0F;
 
     robot_wheel_radius = 0.0625F;
     robot_wheel_separation = 0.358F;

--- a/App/Inc/app/parameters.hpp
+++ b/App/Inc/app/parameters.hpp
@@ -10,10 +10,9 @@ struct Parameters : diff_drive_lib::RobotParams {
     // Wheel
     wheel_encoder_resolution = 878.4F;
     wheel_torque_constant = 1.17647F;
-    wheel_pid_p = 0.0F;
-    wheel_pid_i = 0.005F;
-    wheel_pid_d = 0.0F;
-    wheel_pwm_duty_limit = 100.0F;
+    wheel_pid_p = 2.64F;
+    wheel_pid_i = 42.24F;
+    wheel_pid_d = 0.11F;
 
     robot_wheel_radius = 0.0625F;
     robot_wheel_separation = 0.358F;

--- a/App/Inc/app/parameters.hpp
+++ b/App/Inc/app/parameters.hpp
@@ -19,6 +19,10 @@ struct Parameters : diff_drive_lib::RobotParams {
     robot_wheel_base = 0.3052F;
     robot_angular_velocity_multiplier = 1.76F;
     robot_input_timeout = 500;
+    robot_linear_acceleration = 0.5F;
+    robot_linear_deceleration = 2.0F;
+    robot_angular_acceleration = 2.0F;
+    robot_angular_deceleration = 4.0F;
   }
 
   float battery_min_voltage = 10.0;

--- a/App/Src/app.cpp
+++ b/App/Src/app.cpp
@@ -375,7 +375,7 @@ static bool initROS() {
 
   // Parameter Server
   static rclc_parameter_options_t param_options;
-  param_options.max_params = 14;
+  param_options.max_params = 13;
   param_options.notify_changed_over_dds = true;
   RCCHECK(rclc_parameter_server_init_with_option(&param_server, &node,
                                                  &param_options))
@@ -674,6 +674,11 @@ void update() {
   }
 
   if (status != AgentStatus::AGENT_CONNECTED || !controller_initialized) return;
+
+  MotA.setBatteryVoltage(battery_avg);
+  MotB.setBatteryVoltage(battery_avg);
+  MotC.setBatteryVoltage(battery_avg);
+  MotD.setBatteryVoltage(battery_avg);
 
   controller->update(UPDATE_PERIOD);
 

--- a/App/Src/app.cpp
+++ b/App/Src/app.cpp
@@ -676,10 +676,10 @@ void update() {
 
   if (status != AgentStatus::AGENT_CONNECTED || !controller_initialized) return;
 
-  MotA.setBatteryVoltage(battery_avg);
-  MotB.setBatteryVoltage(battery_avg);
-  MotC.setBatteryVoltage(battery_avg);
-  MotD.setBatteryVoltage(battery_avg);
+  MotA.setSupplyVoltage(battery_avg);
+  MotB.setSupplyVoltage(battery_avg);
+  MotC.setSupplyVoltage(battery_avg);
+  MotD.setSupplyVoltage(battery_avg);
 
   controller->update(UPDATE_PERIOD);
 

--- a/App/Src/app.cpp
+++ b/App/Src/app.cpp
@@ -375,8 +375,9 @@ static bool initROS() {
 
   // Parameter Server
   static rclc_parameter_options_t param_options;
-  param_options.max_params = 13;
+  param_options.max_params = 17;
   param_options.notify_changed_over_dds = true;
+  param_options.low_mem_mode = true;
   RCCHECK(rclc_parameter_server_init_with_option(&param_server, &node,
                                                  &param_options))
   if (!params.init(&param_server)) return false;

--- a/App/Src/app.cpp
+++ b/App/Src/app.cpp
@@ -375,7 +375,7 @@ static bool initROS() {
 
   // Parameter Server
   static rclc_parameter_options_t param_options;
-  param_options.max_params = 17;
+  param_options.max_params = 18;
   param_options.notify_changed_over_dds = true;
   param_options.low_mem_mode = true;
   RCCHECK(rclc_parameter_server_init_with_option(&param_server, &node,

--- a/App/Src/parameters.cpp
+++ b/App/Src/parameters.cpp
@@ -4,9 +4,9 @@ constexpr const char* wheel_encoder_resolution_param_name =
     "wheels/encoder_resolution";
 constexpr const char* wheel_torque_constant_param_name =
     "wheels/torque_constant";
-constexpr const char* wheel_pid_p_param_name = "wheels/pid/v2/p";
-constexpr const char* wheel_pid_i_param_name = "wheels/pid/v2/i";
-constexpr const char* wheel_pid_d_param_name = "wheels/pid/v2/d";
+constexpr const char* wheel_pid_p_param_name = "wheels/pid/v2/kp";
+constexpr const char* wheel_pid_i_param_name = "wheels/pid/v2/ki";
+constexpr const char* wheel_pid_d_param_name = "wheels/pid/v2/kd";
 constexpr const char* mecanum_wheels_param_name = "mecanum_wheels";
 constexpr const char* controller_wheel_radius_param_name =
     "controller/wheel_radius";

--- a/App/Src/parameters.cpp
+++ b/App/Src/parameters.cpp
@@ -108,22 +108,28 @@ bool Parameters::init(rclc_parameter_server_t* param_server) {
 }
 
 inline void get_parameter_double(rclc_parameter_server_t* param_server,
-                                 const char* param_name, float* output) {
+                                 const char* param_name, float* output,
+                                 float min_value = -1e9F) {
   double tmp;
   rclc_parameter_get_double(param_server, param_name, &tmp);
-  *output = static_cast<float>(tmp);
+  float val = static_cast<float>(tmp);
+  *output = val > min_value ? val : min_value;
 }
 
 inline void get_parameter_int(rclc_parameter_server_t* param_server,
-                              const char* param_name, int* output) {
+                              const char* param_name, int* output,
+                              int min_value = -1000000) {
   int64_t tmp;
   rclc_parameter_get_int(param_server, param_name, &tmp);
-  *output = static_cast<int>(tmp);
+  int val = static_cast<int>(tmp);
+  *output = val > min_value ? val : min_value;
 }
+
+constexpr float MIN_POSITIVE = 1e-3F;
 
 void Parameters::update(rclc_parameter_server_t* param_server) {
   get_parameter_double(param_server, wheel_encoder_resolution_param_name,
-                       &wheel_encoder_resolution);
+                       &wheel_encoder_resolution, MIN_POSITIVE);
   get_parameter_double(param_server, wheel_torque_constant_param_name,
                        &wheel_torque_constant);
   get_parameter_double(param_server, wheel_pid_p_param_name, &wheel_pid_p);
@@ -132,26 +138,26 @@ void Parameters::update(rclc_parameter_server_t* param_server) {
   rclc_parameter_get_bool(param_server, mecanum_wheels_param_name,
                           &mecanum_wheels);
   get_parameter_double(param_server, controller_wheel_radius_param_name,
-                       &robot_wheel_radius);
+                       &robot_wheel_radius, MIN_POSITIVE);
   get_parameter_double(param_server, controller_wheel_separation_param_name,
-                       &robot_wheel_separation);
+                       &robot_wheel_separation, MIN_POSITIVE);
   get_parameter_double(param_server, controller_wheel_base_param_name,
-                       &robot_wheel_base);
+                       &robot_wheel_base, 0.0F);
   get_parameter_double(param_server,
                        controller_angular_velocity_multiplier_param_name,
-                       &robot_angular_velocity_multiplier);
+                       &robot_angular_velocity_multiplier, MIN_POSITIVE);
   get_parameter_int(param_server, controller_input_timeout_param_name,
-                    &robot_input_timeout);
+                    &robot_input_timeout, 0);
   get_parameter_double(param_server, controller_linear_acceleration_param_name,
-                       &robot_linear_acceleration);
+                       &robot_linear_acceleration, 0.0F);
   get_parameter_double(param_server, controller_linear_deceleration_param_name,
-                       &robot_linear_deceleration);
+                       &robot_linear_deceleration, 0.0F);
   get_parameter_double(param_server, controller_angular_acceleration_param_name,
-                       &robot_angular_acceleration);
+                       &robot_angular_acceleration, 0.0F);
   get_parameter_double(param_server, controller_angular_deceleration_param_name,
-                       &robot_angular_deceleration);
+                       &robot_angular_deceleration, 0.0F);
   get_parameter_double(param_server, battery_min_voltage_param_name,
-                       &battery_min_voltage);
+                       &battery_min_voltage, 0.0F);
   get_parameter_int(param_server, leo_hardware_version_param_name,
-                    &leo_hardware_version);
+                    &leo_hardware_version, 1);
 }

--- a/App/Src/parameters.cpp
+++ b/App/Src/parameters.cpp
@@ -4,10 +4,9 @@ constexpr const char* wheel_encoder_resolution_param_name =
     "wheels/encoder_resolution";
 constexpr const char* wheel_torque_constant_param_name =
     "wheels/torque_constant";
-constexpr const char* wheel_pid_p_param_name = "wheels/pid/p";
-constexpr const char* wheel_pid_i_param_name = "wheels/pid/i";
-constexpr const char* wheel_pid_d_param_name = "wheels/pid/d";
-constexpr const char* wheel_pwm_duty_limit_param_name = "wheels/pwm_duty_limit";
+constexpr const char* wheel_pid_p_param_name = "wheels/pid/v2/p";
+constexpr const char* wheel_pid_i_param_name = "wheels/pid/v2/i";
+constexpr const char* wheel_pid_d_param_name = "wheels/pid/v2/d";
 constexpr const char* mecanum_wheels_param_name = "mecanum_wheels";
 constexpr const char* controller_wheel_radius_param_name =
     "controller/wheel_radius";
@@ -67,8 +66,6 @@ bool Parameters::init(rclc_parameter_server_t* param_server) {
       init_parameter_double(param_server, wheel_pid_i_param_name, wheel_pid_i))
   RCCHECK(
       init_parameter_double(param_server, wheel_pid_d_param_name, wheel_pid_d))
-  RCCHECK(init_parameter_double(param_server, wheel_pwm_duty_limit_param_name,
-                                wheel_pwm_duty_limit))
   RCCHECK(init_parameter_bool(param_server, mecanum_wheels_param_name,
                               mecanum_wheels))
   RCCHECK(init_parameter_double(
@@ -112,8 +109,6 @@ void Parameters::update(rclc_parameter_server_t* param_server) {
   get_parameter_double(param_server, wheel_pid_p_param_name, &wheel_pid_p);
   get_parameter_double(param_server, wheel_pid_i_param_name, &wheel_pid_i);
   get_parameter_double(param_server, wheel_pid_d_param_name, &wheel_pid_d);
-  get_parameter_double(param_server, wheel_pwm_duty_limit_param_name,
-                       &wheel_pwm_duty_limit);
   rclc_parameter_get_bool(param_server, mecanum_wheels_param_name,
                           &mecanum_wheels);
   get_parameter_double(param_server, controller_wheel_radius_param_name,

--- a/App/Src/parameters.cpp
+++ b/App/Src/parameters.cpp
@@ -7,6 +7,7 @@ constexpr const char* wheel_torque_constant_param_name =
 constexpr const char* wheel_pid_p_param_name = "wheels.pid.kp";
 constexpr const char* wheel_pid_i_param_name = "wheels.pid.ki";
 constexpr const char* wheel_pid_d_param_name = "wheels.pid.kd";
+constexpr const char* wheel_max_voltage_param_name = "wheels.max_voltage";
 constexpr const char* mecanum_wheels_param_name = "mecanum_wheels";
 constexpr const char* controller_wheel_radius_param_name =
     "controller.wheel_radius";
@@ -74,6 +75,8 @@ bool Parameters::init(rclc_parameter_server_t* param_server) {
       init_parameter_double(param_server, wheel_pid_i_param_name, wheel_pid_i))
   RCCHECK(
       init_parameter_double(param_server, wheel_pid_d_param_name, wheel_pid_d))
+  RCCHECK(init_parameter_double(param_server, wheel_max_voltage_param_name,
+                                wheel_max_voltage))
   RCCHECK(init_parameter_bool(param_server, mecanum_wheels_param_name,
                               mecanum_wheels))
   RCCHECK(init_parameter_double(
@@ -135,6 +138,8 @@ void Parameters::update(rclc_parameter_server_t* param_server) {
   get_parameter_double(param_server, wheel_pid_p_param_name, &wheel_pid_p);
   get_parameter_double(param_server, wheel_pid_i_param_name, &wheel_pid_i);
   get_parameter_double(param_server, wheel_pid_d_param_name, &wheel_pid_d);
+  get_parameter_double(param_server, wheel_max_voltage_param_name,
+                       &wheel_max_voltage, 0.0F);
   rclc_parameter_get_bool(param_server, mecanum_wheels_param_name,
                           &mecanum_wheels);
   get_parameter_double(param_server, controller_wheel_radius_param_name,

--- a/App/Src/parameters.cpp
+++ b/App/Src/parameters.cpp
@@ -18,6 +18,14 @@ constexpr const char* controller_angular_velocity_multiplier_param_name =
     "controller/angular_velocity_multiplier";
 constexpr const char* controller_input_timeout_param_name =
     "controller/input_timeout";
+constexpr const char* controller_linear_acceleration_param_name =
+    "controller/linear_acceleration";
+constexpr const char* controller_linear_deceleration_param_name =
+    "controller/linear_deceleration";
+constexpr const char* controller_angular_acceleration_param_name =
+    "controller/angular_acceleration";
+constexpr const char* controller_angular_deceleration_param_name =
+    "controller/angular_deceleration";
 constexpr const char* battery_min_voltage_param_name = "battery_min_voltage";
 constexpr const char* leo_hardware_version_param_name = "leo_hardware_version";
 
@@ -80,6 +88,18 @@ bool Parameters::init(rclc_parameter_server_t* param_server) {
       robot_angular_velocity_multiplier))
   RCCHECK(init_parameter_int(param_server, controller_input_timeout_param_name,
                              robot_input_timeout))
+  RCCHECK(init_parameter_double(param_server,
+                                controller_linear_acceleration_param_name,
+                                robot_linear_acceleration))
+  RCCHECK(init_parameter_double(param_server,
+                                controller_linear_deceleration_param_name,
+                                robot_linear_deceleration))
+  RCCHECK(init_parameter_double(param_server,
+                                controller_angular_acceleration_param_name,
+                                robot_angular_acceleration))
+  RCCHECK(init_parameter_double(param_server,
+                                controller_angular_deceleration_param_name,
+                                robot_angular_deceleration))
   RCCHECK(init_parameter_double(param_server, battery_min_voltage_param_name,
                                 battery_min_voltage))
   RCCHECK(init_parameter_int(param_server, leo_hardware_version_param_name,
@@ -122,6 +142,14 @@ void Parameters::update(rclc_parameter_server_t* param_server) {
                        &robot_angular_velocity_multiplier);
   get_parameter_int(param_server, controller_input_timeout_param_name,
                     &robot_input_timeout);
+  get_parameter_double(param_server, controller_linear_acceleration_param_name,
+                       &robot_linear_acceleration);
+  get_parameter_double(param_server, controller_linear_deceleration_param_name,
+                       &robot_linear_deceleration);
+  get_parameter_double(param_server, controller_angular_acceleration_param_name,
+                       &robot_angular_acceleration);
+  get_parameter_double(param_server, controller_angular_deceleration_param_name,
+                       &robot_angular_deceleration);
   get_parameter_double(param_server, battery_min_voltage_param_name,
                        &battery_min_voltage);
   get_parameter_int(param_server, leo_hardware_version_param_name,

--- a/App/Src/parameters.cpp
+++ b/App/Src/parameters.cpp
@@ -1,5 +1,8 @@
 #include "app/parameters.hpp"
 
+#include <cmath>
+#include <cstdint>
+
 constexpr const char* wheel_encoder_resolution_param_name =
     "wheels.encoder_resolution";
 constexpr const char* wheel_torque_constant_param_name =
@@ -116,7 +119,9 @@ inline void get_parameter_double(rclc_parameter_server_t* param_server,
   double tmp;
   rclc_parameter_get_double(param_server, param_name, &tmp);
   float val = static_cast<float>(tmp);
-  *output = val > min_value ? val : min_value;
+  if (std::isfinite(val)) {
+    *output = val > min_value ? val : min_value;
+  }
 }
 
 inline void get_parameter_int(rclc_parameter_server_t* param_server,
@@ -124,6 +129,11 @@ inline void get_parameter_int(rclc_parameter_server_t* param_server,
                               int min_value = -1000000) {
   int64_t tmp;
   rclc_parameter_get_int(param_server, param_name, &tmp);
+  if (tmp > INT32_MAX) {
+    tmp = INT32_MAX;
+  } else if (tmp < INT32_MIN) {
+    tmp = INT32_MIN;
+  }
   int val = static_cast<int>(tmp);
   *output = val > min_value ? val : min_value;
 }

--- a/App/Src/parameters.cpp
+++ b/App/Src/parameters.cpp
@@ -1,31 +1,31 @@
 #include "app/parameters.hpp"
 
 constexpr const char* wheel_encoder_resolution_param_name =
-    "wheels/encoder_resolution";
+    "wheels.encoder_resolution";
 constexpr const char* wheel_torque_constant_param_name =
-    "wheels/torque_constant";
-constexpr const char* wheel_pid_p_param_name = "wheels/pid/v2/kp";
-constexpr const char* wheel_pid_i_param_name = "wheels/pid/v2/ki";
-constexpr const char* wheel_pid_d_param_name = "wheels/pid/v2/kd";
+    "wheels.torque_constant";
+constexpr const char* wheel_pid_p_param_name = "wheels.pid.kp";
+constexpr const char* wheel_pid_i_param_name = "wheels.pid.ki";
+constexpr const char* wheel_pid_d_param_name = "wheels.pid.kd";
 constexpr const char* mecanum_wheels_param_name = "mecanum_wheels";
 constexpr const char* controller_wheel_radius_param_name =
-    "controller/wheel_radius";
+    "controller.wheel_radius";
 constexpr const char* controller_wheel_separation_param_name =
-    "controller/wheel_separation";
+    "controller.wheel_separation";
 constexpr const char* controller_wheel_base_param_name =
-    "controller/wheel_base";
+    "controller.wheel_base";
 constexpr const char* controller_angular_velocity_multiplier_param_name =
-    "controller/angular_velocity_multiplier";
+    "controller.angular_velocity_multiplier";
 constexpr const char* controller_input_timeout_param_name =
-    "controller/input_timeout";
+    "controller.input_timeout";
 constexpr const char* controller_linear_acceleration_param_name =
-    "controller/linear_acceleration";
+    "controller.linear_acceleration";
 constexpr const char* controller_linear_deceleration_param_name =
-    "controller/linear_deceleration";
+    "controller.linear_deceleration";
 constexpr const char* controller_angular_acceleration_param_name =
-    "controller/angular_acceleration";
+    "controller.angular_acceleration";
 constexpr const char* controller_angular_deceleration_param_name =
-    "controller/angular_deceleration";
+    "controller.angular_deceleration";
 constexpr const char* battery_min_voltage_param_name = "battery_min_voltage";
 constexpr const char* leo_hardware_version_param_name = "leo_hardware_version";
 


### PR DESCRIPTION
This PR updates the project to use a newer version of diff_drive_lib, which:
- Updates PID regulator to integrate/differentiate using seconds and output voltage applied to the motor, instead of percent of PWM - this makes the gain coefficients more physically meaningful and keeps the behavior consistent on different battery voltages. (for example, the P gain of 1.0 will apply 1 Volt per every 1 rad/s error between target and measured velocity)
- Adds linear/angular acceleration & deceleration limiting

On the firmware side, the following changes were applied:
- Removed `wheel_pwm_duty_limit` parameter and replaced it with `wheel_max_voltage`.
- Added linear/angular acceleration/deceleration parameters. 
- Tuned PID and acceleration parameters to somewhat replicate the earlier behavior.
- Since there was no more spare RAM, changed parameter server configuration to use [Low memory mode](https://docs.vulcanexus.org/en/jazzy/rst/microros_documentation/user_api/user_api_parameter_server.html#low-memory-mode)
- Clamped some parameter values to make sure setting some parameters to negative or zero does not crash the firmware.